### PR TITLE
Make vrrp check more generic

### DIFF
--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -7,7 +7,7 @@
     }   
 
     vrrp_script chk_haproxy {
-        script       "ss -ltn 'src {{VIRTUAL_IP}}' | grep {{CHECK_PORT}}"
+        script       "ss -ltn 'src :' | grep {{CHECK_PORT}}"
         timeout 1
         interval 1   # check every 1 second
         fall 2       # require 2 failures for KO


### PR DESCRIPTION
The default keepalived.conf check does not work with most scenarios. Removing the IP Address from the check solves the problem and makes the default container configuration good for most cases.
