### PR TITLE
Revert "Make vrrp check more generic"

### DIFF
--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -7,7 +7,7 @@
     }   
 
     vrrp_script chk_haproxy {
-        script       "ss -ltn 'src :' | grep {{CHECK_PORT}}"
+        script       "ss -ltn 'src {{VIRTUAL_IP}}' | grep {{CHECK_PORT}}"
         timeout 1
         interval 1   # check every 1 second
         fall 2       # require 2 failures for KO


### PR DESCRIPTION
Reverts NeoAssist/docker-keepalived#3

Reverting and adding information on the readme in order to correctly support multiple IPs and prevent false positives in case a service is listening on another ip...
