### PR TITLE
Allow more ips and remove the source ip for checking

### DIFF
--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -7,7 +7,7 @@
     }   
 
     vrrp_script chk_haproxy {
-        script       "ss -ltn 'src {{VIRTUAL_IP}}' | grep {{CHECK_PORT}}"
+        script       "ss -ltn | grep {{CHECK_PORT}}"
         timeout 1
         interval 1   # check every 1 second
         fall 2       # require 2 failures for KO

--- a/docker-keepalived/keepalived.sh
+++ b/docker-keepalived/keepalived.sh
@@ -33,7 +33,7 @@ fi
 
 # Make sure the variables we need to run are populated and (roughly) valid
 
-if ! [[ $VIRTUAL_IP =~ ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-2][0-3])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ ]]; then
+if ! [[ $VIRTUAL_IP =~ ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ ]]; then
   echo "The VIRTUAL_IP environment variable is null or not a valid IP address, exiting..."
   exit 1
 fi


### PR DESCRIPTION
The Racnher HA load balanacer register listen on all interfaces and ip if you only specify the port for host adress, therefore the check script fails although the host is serving requests on the specified port.

Also the virtual IP is good to be able to use "real" ip:s so it fits with the rest of the infrastructure and routers on the way from Internet into the host running Docker.
