### PR TITLE
Fix VIRTUAL_IP regex

### DIFF
--- a/docker-keepalived/keepalived.sh
+++ b/docker-keepalived/keepalived.sh
@@ -29,7 +29,7 @@ stop()
 
 # Make sure the variables we need to run are populated and (roughly) valid
 
-if ! [[ $VIRTUAL_IP =~ ^(([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-5][0-5])\.){3}([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-5][0-5])$ ]]; then
+if ! [[ $VIRTUAL_IP =~ ^([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]]; then
   echo "The VIRTUAL_IP environment variable is null or not a valid IP address, exiting..."
   exit 1
 fi

--- a/docker-keepalived/keepalived.sh
+++ b/docker-keepalived/keepalived.sh
@@ -29,7 +29,7 @@ stop()
 
 # Make sure the variables we need to run are populated and (roughly) valid
 
-if ! [[ $VIRTUAL_IP =~ ^([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]]; then
+if ! [[ $VIRTUAL_IP =~ ^(([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-2][0-3])\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-5][0-5])\.){2}([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-5][0-5])$ ]]; then
   echo "The VIRTUAL_IP environment variable is null or not a valid IP address, exiting..."
   exit 1
 fi


### PR DESCRIPTION
The regex wouldn't allow for 0s in any field. For example, if I need to use 192.168.0.11 (a valid IP) it would throw an error. It's a lot uglier, but it works!