### PR TITLE
Use community instead of testing branch

### DIFF
--- a/docker-keepalived/Dockerfile
+++ b/docker-keepalived/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+RUN echo "http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     apk --update -t add keepalived iproute2 grep bash tcpdump sed && \
     rm -f /var/cache/apk/* /tmp/*


### PR DESCRIPTION
Looks like keepalived moved to the edge community branch and it's libressl deps are in edge main, so there is no need for the edge testing branch anymore