### PR TITLE
Changed default authentication from PASS to AH and set a password

### DIFF
--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -26,7 +26,7 @@
         }
         authentication {
             auth_type PASS
-            auth_pass blahblah
+            auth_pass {{AUTH_PASS}}
         }
         virtual_ipaddress {
             {{VIRTUAL_IP}}/24 dev {{INTERFACE}}

--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -25,7 +25,7 @@
             chk_haproxy
         }
         authentication {
-            auth_type PASS
+            auth_type AH
             auth_pass {{AUTH_PASS}}
         }
         virtual_ipaddress {

--- a/docker-keepalived/keepalived.sh
+++ b/docker-keepalived/keepalived.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+if [ -z "$AUTH_PASS" ]; then
+  AUTH_PASS="changeme"
+fi
+
 # Substitute variables in config file.
 /bin/sed -i "s/{{VIRTUAL_IP}}/${VIRTUAL_IP}/" /etc/keepalived/keepalived.conf
 /bin/sed -i "s/{{CHECK_PORT}}/${CHECK_PORT}/" /etc/keepalived/keepalived.conf
 /bin/sed -i "s/{{VRID}}/${VRID}/" /etc/keepalived/keepalived.conf
+/bin/sed -i "s/{{AUTH_PASS}}/${AUTH_PASS}/" /etc/keepalived/keepalived.conf
 /bin/sed -i "s/{{INTERFACE}}/${INTERFACE}/" /etc/keepalived/keepalived.conf
 
 # Make sure we react to these signals by running stop() when we see them - for clean shutdown
@@ -40,6 +45,10 @@ fi
 if ! [[ $INTERFACE =~ ^.*[0-9]$ ]]; then
   echo "The INTERFACE environment variable is null or doesn't end in a number, exiting..."
   exit 1
+fi
+
+if [ "$AUTH_PASS" == "changeme" ]; then
+  echo "WARNING: You should change the authentication passsword variable AUTH_PASS for security reasons."
 fi
 
 # This loop runs till until we've started up successfully


### PR DESCRIPTION
For security reasons, it is recommended to change de default authentication method to AH, and change the default authentication password.