### PR TITLE
health check: port unambiguous

### DIFF
--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -8,7 +8,7 @@
     }   
 
     vrrp_script chk_haproxy {
-        script       "ss -ltn 'src {{CHECK_IP}}' | grep {{CHECK_PORT}}"
+        script       "ss -ltn 'src {{CHECK_IP}}' | grep ':{{CHECK_PORT}} '"
         timeout 1
         interval 1   # check every 1 second
         fall 2       # require 2 failures for KO


### PR DESCRIPTION
The use of `grep` matching only the port number is ambiguous. It can match any port number that contains `CHECK_PORT`, as 8080, 6080, etc. That will prevent a proper failover.

I have prepended a semicolon and appended a blank `' '` to avoid it.