### PR TITLE
Remove hardcoded eth0 interface in vrrp

### DIFF
--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -17,7 +17,7 @@
 
     vrrp_instance lb-vips {
         state BACKUP
-        interface eth0
+        interface {{INTERFACE}}
         virtual_router_id {{VRID}}
         priority 100
         advert_int 1


### PR DESCRIPTION
replaced with {{INTEFACE}} parameter. Some Linux flavors have departed from eth0, etc.  https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/