### PR TITLE
Change check script and make it customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It has been designed specifically for use within [Rancher](http://rancher.com/) 
 
 ## Services & Address Binding
 
-HAProxy (and most other listening services) won't bind to an address that doesn't exist within the host's network stack. As Keepalived will only host any particular VIP on a single host, the service(s) on the remaining ones will not be able to bind to the VIP address and will likely fail. Keepalived on those hosts will also fail as it is performing a health check on the service itself (by checking for a listener on the VIP address and the service port you specify). 
+HAProxy (and most other listening services) won't bind to an address that doesn't exist within the host's network stack. As Keepalived will only host any particular VIP on a single host, the service(s) on the remaining ones will not be able to bind to the VIP address and will likely fail. Keepalived on those hosts will also fail as it is performing a health check on the service itself (by checking for a listener on the VIP address and the service port you specify).
 
 In order to avoid this issue, you can either;
 
@@ -39,7 +39,7 @@ If your not using the default console, see the prior section for Most Distros. I
 If you don't already have a **/opt/rancher/bin/start.sh** startup file, edit the **/var/lib/rancher/conf/cloud-config.d/user_config.yml** file and add this to it to create a suitable file which will run the `sysctl -p` command:
 ```
 write_files:
-  - encoding: b64 
+  - encoding: b64
     content: IyEvYmluL3NoCnN5c2N0bCAtcApleGl0Cg==
     owner: root:root
     path: /opt/rancher/bin/start.sh
@@ -50,7 +50,7 @@ If you do already have this file, add the `sysctl -p` command to it.
 In either case, add this to the end of the **/var/lib/rancher/conf/cloud-config.d/user_config.yml** file to create a suitable **/etc/sysctl.conf** file:
 ```
 write_files:
-  - encoding: b64 
+  - encoding: b64
     content: bmV0LmlwdjQuY29uZi5hbGwuYXJwX2FjY2VwdCA9IDEgCm5ldC5pcHY0LmlwX25vbmxvY2FsX2JpbmQgPSAxIApuZXQuaXB2NC5jb25mLmFsbC5wcm9tb3RlX3NlY29uZGFyaWVzID0gMQo=
     owner: root:root
     path: /etc/sysctl.conf
@@ -61,22 +61,24 @@ Reboot to have the files written and executed.
 ### Enabling Non-local Binding - CoreOS
 
 Use this command: `#/bin/sh -c "/usr/sbin/sysctl -w net.ipv4.ip_nonlocal_bind=1` or add this to a unit file with a oneshot execution.
-  
+
 *Other distributions may have slightly different commands or syntax...google is your friend!*
 
 **This is still a work in progress, constantly being changed and probably not ready, even for any real testing...**
 
 ## Health Checks
 
-If you'd like the health check to only check for something listening on a specified port, rather than an address and port, you can set the CHECK_IP variable value to `any`.
+If you'd like the health check to only check for something listening on a specified port, rather than an address and port, only set the CHECK_PORT variable, not the CHECK_IP variable.
 
 If you do want to check the address and port combination, set the CHECK_IP variable to the same value as the VIRTUAL_IP variable.
 
-Note that due to the way Rancher works, you cannot perform a port check for another Rancher service which has a port mapped/bound to/from the host. This won't show up in the output of the `ss` or `netstat` commands. To overcome this;
+If you want to use your own custom script, set the CHECK_SCRIPT variable.
+
+If using a custom script, note that due to the way Rancher works, you cannot perform a port check for another Rancher service which has a port mapped/bound to/from the host. This won't show up in the output of the `ss` or `netstat` commands. To overcome this;
 - Switch to a different kind of monitor, such as a HTTP check.
 - Configure the other service to use host mode.
 
-If you plan on using some other kind of health check which relies on the ability to use DNS names to connect to another Rancher service, ensure you add the `io.rancher.container.dns` label to this service's compose definition and set it's value to `'true'`. 
+If you plan on using some other kind of health check which relies on the ability to use DNS names to connect to another Rancher service, ensure you add the `io.rancher.container.dns` label to this service's compose definition and set it's value to `'true'`.
 
 ## Thanks & Inspiration
 

--- a/docker-keepalived/keepalived.conf
+++ b/docker-keepalived/keepalived.conf
@@ -4,16 +4,16 @@
         vrrp_garp_master_delay 1
         vrrp_garp_master_refresh
         #Uncomment the next line if you'd like to use unique multicast groups
-        #vrrp_mcast_group4 224.0.0.{{VRID}}	
-    }   
+        #vrrp_mcast_group4 224.0.0.{{VRID}}
+    }
 
     vrrp_script chk_haproxy {
-        script       "ss -ltn 'src {{CHECK_IP}}' | grep ':{{CHECK_PORT}} '"
+        script       "{{CHECK_SCRIPT}}"
         timeout 1
         interval 1   # check every 1 second
         fall 2       # require 2 failures for KO
         rise 2       # require 2 successes for OK
-    }   
+    }
 
     vrrp_instance lb-vips {
         state BACKUP
@@ -32,4 +32,4 @@
         virtual_ipaddress {
             {{VIRTUAL_IP}}/{{VIRTUAL_MASK}} dev {{INTERFACE}}
         }
-    } 
+    }

--- a/docker-keepalived/keepalived.sh
+++ b/docker-keepalived/keepalived.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+# Setup check script
+if [[ -z ${CHECK_SCRIPT} ]]; then
+  if [[ -z ${CHECK_IP} ]] || [[ ${CHECK_IP} = 'any' ]]; then
+    CHECK_SCRIPT="iptables -t nat -nL CATTLE_PREROUTING | grep ':${CHECK_PORT}'"
+  else
+    CHECK_SCRIPT="iptables -nL | grep '${CHECK_IP}' && iptables -t nat -nL CATTLE_PREROUTING | grep ':${CHECK_PORT}'"
+  fi
+fi
+
 # Substitute variables in config file.
 /bin/sed -i "s/{{VIRTUAL_IP}}/${VIRTUAL_IP}/g" /etc/keepalived/keepalived.conf
 /bin/sed -i "s/{{VIRTUAL_MASK}}/${VIRTUAL_MASK}/g" /etc/keepalived/keepalived.conf
-/bin/sed -i "s/{{CHECK_IP}}/${CHECK_IP}/g" /etc/keepalived/keepalived.conf
-/bin/sed -i "s/{{CHECK_PORT}}/${CHECK_PORT}/g" /etc/keepalived/keepalived.conf
+/bin/sed -i "s/{{CHECK_SCRIPT}}/${CHECK_SCRIPT}/g" /etc/keepalived/keepalived.conf
 /bin/sed -i "s/{{VRID}}/${VRID}/g" /etc/keepalived/keepalived.conf
 /bin/sed -i "s/{{INTERFACE}}/${INTERFACE}/g" /etc/keepalived/keepalived.conf
 


### PR DESCRIPTION
In newer versions of Rancher, the LB service does not publish the ports on the host. See #20 

One way to check the port is through `iptables`. I made a script that utilizes this and set it is as the new default script but also let users inject their own check script if they want.

I kept functionality for users who have `CHECK_IP=any` set in order to keep backwards compatibility.

(The whitespace changes must have been my text editor auto-fixing).